### PR TITLE
Format hours and other fixes

### DIFF
--- a/formatter/formatting.go
+++ b/formatter/formatting.go
@@ -48,7 +48,8 @@ func FormatDiff(t time.Duration, pb time.Duration, isBule bool) string {
 }
 
 func FormatWithMinutes(d time.Duration) string {
-	minutes := d / time.Minute
+	hours := d / time.Hour
+	minutes := (d / time.Minute) - (60 * hours)
 
 	tenths := d / (100 * time.Millisecond)
 	seconds := d / time.Second
@@ -56,5 +57,5 @@ func FormatWithMinutes(d time.Duration) string {
 	tenths %= 10
 	seconds %= 60
 
-	return fmt.Sprintf("%02d:%02d.%01d", minutes, seconds, tenths)
+	return fmt.Sprintf("%02d:%02d:%02d.%01d", hours, minutes, seconds, tenths)
 }

--- a/handler/times.go
+++ b/handler/times.go
@@ -13,9 +13,9 @@ func SaveTimes(m map[Level]time.Duration, typ string) {
 	var db File
 
 	cr := LoadFile().CustomRuns
+	pb := LoadFile().Pb
 
 	if typ == "bule" {
-		pb := LoadFile().Pb
 
 		buleTimes := MergeBule(m, LoadBule())
 
@@ -26,9 +26,8 @@ func SaveTimes(m map[Level]time.Duration, typ string) {
 		return
 	}
 
-	run := Run{m, LoadFile().Pb["any"].Levelnames}
-	pb := make(map[string]Run)
-	pb["any"] = run
+	run := Run{m, LoadFile().Pb[typ].Levelnames}
+	pb[typ] = run
 
 	buleTimes := MergeBule(m, LoadBule())
 

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -107,7 +107,7 @@ func RunOverlay(file string, info bool, splits bool, routeP string, number bool,
 					pbD += pbTimes[k]
 
 				}
-				if d < pbD {
+				if d < pbD || len(pbTimes) == 0 {
 					//log.Printf("new pb, congratulations!")
 					pbTimes = times
 					handler.SaveTimes(pbTimes, routeP)
@@ -123,7 +123,7 @@ func RunOverlay(file string, info bool, splits bool, routeP string, number bool,
 }
 
 func ShowBest(info bool, splits bool, route string, number bool, side bool) {
-	pbTimes = handler.LoadRun("any")
+	pbTimes = handler.LoadRun(route)
 	buleTimes = handler.LoadBule()
 
 	c := make(chan os.Signal, 1)


### PR DESCRIPTION
This PR adds support to display hours to make it more readable and inline with IGT.

Furthermore this fixes the following:

- PB not being saved when no initial PB exists
- Saving PB for custom routes
- Showing PB for custom routes