### PR TITLE
Fix crash when saving pb to file with null pb

### DIFF
--- a/handler/times.go
+++ b/handler/times.go
@@ -26,6 +26,10 @@ func SaveTimes(m map[Level]time.Duration, typ string) {
 		return
 	}
 
+        if pb == nil {
+                pb = make(map[string]Run)
+        }
+
 	run := Run{m, LoadFile().Pb[typ].Levelnames}
 	pb[typ] = run
 


### PR DESCRIPTION
The most recent patch introduced a bug that causes the program to crash when attempting to save a PB to a file where PB is null. This was caused by the removal of `pb := make(map[string]Run)`. It is now present under the condition `pb == nil`.

```
panic: assignment to entry in nil map

goroutine 1 [running]:
casf/handler.SaveTimes(0xc0000cfa40, {0x5cfc3f, 0x3})
        /home/lazula/Celeste/cas-farewell/handler/times.go:30 +0x2e5
casf/timer.RunOverlay({0x724118, 0x1}, 0x1, 0x1, {0x5cfc3f, 0x3}, 0x0, 0x0)
        /home/lazula/Celeste/cas-farewell/timer/timer.go:113 +0xc9d
casf/timer.StartTimer.func1(0xc0000f0000)
        /home/lazula/Celeste/cas-farewell/timer/cli.go:78 +0x3c7
github.com/urfave/cli.HandleAction({0x5a1960?, 0x5e2310?}, 0xc0000e8000?)
        /home/lazula/go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:524 +0xa8
github.com/urfave/cli.(*App).Run(0xc0000e8000, {0xc000010040, 0x2, 0x2})
        /home/lazula/go/pkg/mod/github.com/urfave/cli@v1.22.5/app.go:286 +0x7c5
casf/timer.StartTimer()
        /home/lazula/Celeste/cas-farewell/timer/cli.go:200 +0xef4
main.main()
        /home/lazula/Celeste/cas-farewell/main.go:15 +0x73
```