### PR TITLE
Fix crash due to race condition when save file is updated

### DIFF
--- a/handler/times.go
+++ b/handler/times.go
@@ -56,8 +56,7 @@ func ParseSaveFile(path string) map[Level]time.Duration {
 	err = d.Decode(&s)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "corrupted or missing savefile!\n")
-		log.Fatal(err)
+                return nil
 	}
 
 	for _, area := range s.Areas {

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -93,7 +93,14 @@ func RunOverlay(file string, info bool, splits bool, routeP string, number bool,
 			case fsnotify.Chmod:
 				fallthrough
 			case fsnotify.Write:
-				times = handler.ParseSaveFile(saveFile)
+                                var new_times map[handler.Level]time.Duration = nil
+                                for {
+				        new_times = handler.ParseSaveFile(saveFile)
+                                        if new_times != nil {
+                                                break
+                                        }
+                                }
+                                times = new_times
 			}
 
 			printTimes(times, info, splits, routeP, number, side)


### PR DESCRIPTION
Steps to reproduce:

```
# first terminal
$ git checkout main && go build && ./casf
# second terminal - simulate game saving
$ watch -n0.1 cp arbitrary_save_file.celeste ~/.local/share/Celeste/Saves/2.celeste
```

Eventually, the program will crash with "corrupted or missing savefile" and EOF. It may happen immediately or after several attempts. My uneducated guess is that fsnotify.Write triggers as soon as the file is opened in write mode/truncated and the file is being loaded for XML parsing before the write is complete.

This patch prevents this from happening by replacing the crash with `return nil` and re-checking the file until it can be parsed correctly. If there's a better way to handle this in go, feel free to edit.